### PR TITLE
Fix: crash caused by crypto.randomUUID()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-icons": "^5.3.0",
         "react-router-dom": "^7.0.1",
         "react-use-websocket": "^4.3.1",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-icons": "^5.3.0",
     "react-router-dom": "^7.0.1",
     "react-use-websocket": "^4.3.1",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^2.10.1",

--- a/src/mappers/generatorsDtoToFm.mapper.ts
+++ b/src/mappers/generatorsDtoToFm.mapper.ts
@@ -3,12 +3,13 @@ import type { GeneratorDto } from "../types/apis/dataTransferObject/generatorsDt
 import type { GeothermalGeneratorDto } from "../types/apis/dataTransferObject/geothermalGeneratorDto";
 import type { GeneratorFm } from "../types/apis/frontModel/generatorsFm";
 import { enumDtoToFmMapper } from "./enumDtoToFm.mapper";
+import { v4 as uuidv4 } from 'uuid';
 
 export const generatorsDtoToFmMapper = (
   dto: GeneratorDto[] | GeothermalGeneratorDto[],
 ): GeneratorFm[] => {
   return dto.map((generatorDto) => ({
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     className: enumDtoToFmMapper(
       generatorDto.ClassName,
       GameClassNamesEnum,

--- a/src/react/components/sidebar.tsx
+++ b/src/react/components/sidebar.tsx
@@ -145,9 +145,9 @@ export const Sidebar: React.FC = () => {
             </IconButton>
           </Tooltip>
         )}
-        {linksGroup.map((group) => {
+        {linksGroup.map((group, index) => {
           return (
-            <React.Fragment key={crypto.randomUUID()}>
+            <React.Fragment key={index}>
               <Divider />
               {group.map((link) => {
                 if (link.isDisabled) return null;


### PR DESCRIPTION
The app crashed (black screen) when accessed via HTTP because crypto.randomUUID() is not available in non-secure contexts, e.g., if self-hosted without SSL.

Changes:
Replaced all usages of crypto.randomUUID()
Used stable React keys in the Sidebar
Replaced ID generation in data mapping with a compatible alternative